### PR TITLE
Fixes MediaQuery Nesting Issue

### DIFF
--- a/chrome/content/reps.js
+++ b/chrome/content/reps.js
@@ -21,26 +21,40 @@ FBL.ns(function() { with (FBL) {
         }
 
         var rules = sourceLink.object.parentStyleSheet.cssRules;
-        for(var i=0; i<rules.length-1; i++)
-        {
-            var styleRule = rules[i+1];
-            if (styleRule.type != CSSRule.STYLE_RULE) continue;
-            styleRule.sassDebugInfo = {};
-
-            var mediaRule = rules[i];
-            if (mediaRule.type != CSSRule.MEDIA_RULE) continue;
-
-            if (mediaRule.media.mediaText != "-sass-debug-info") continue;
-
-            for (var j=0; j<mediaRule.cssRules.length; j++)
-            {
-                styleRule.sassDebugInfo[mediaRule.cssRules[j].selectorText] =
-                    mediaRule.cssRules[j].style.getPropertyValue("font-family");
-            }
-        }
+        parseCssRules(rules);
 
         sourceLink.sassDebugInfo = sourceLink.object.sassDebugInfo || {};
         return;
+    }
+
+    function parseCssRules(rules) {
+
+        for(var i=0; i<rules.length; i++) {
+            var mediaRule = rules[i],
+                styleRule = rules[i+1];
+
+            // We only care about media rules.
+            if (mediaRule.type === CSSRule.MEDIA_RULE) {
+
+                // If this is a 'regular' mediaquery, dive in and parse its internal rules.
+                if (mediaRule.media.mediaText !== "-sass-debug-info") {
+                    parseCssRules(mediaRule.cssRules);
+                    continue;
+                };
+
+                // If this is a firesass mediaquery and the next rule is a style rule, get the debug info.
+                if ( mediaRule.media.mediaText === "-sass-debug-info" && styleRule.type === CSSRule.STYLE_RULE ) {
+
+                    styleRule.sassDebugInfo = {};
+
+                    for (var j=0; j<mediaRule.cssRules.length; j++)
+                    {
+                        styleRule.sassDebugInfo[mediaRule.cssRules[j].selectorText] =
+                            mediaRule.cssRules[j].style.getPropertyValue("font-family");
+                    }
+                }
+            };
+        }
     }
 
     sl.getSourceLinkTitle = function(sourceLink)


### PR DESCRIPTION
Saw this fix:

https://github.com/nex3/firesass/pull/12

But it didn't work for me. Looking into it, firesass (and this fix) fail to dive into all the possible nested media queries that might occur. So I pulled the scraper functionality out of cacheSassDebugInfo() and had it call itself whenever it found a non-debug media query.

To reproduce the issue, wrap your scss with:

```
@media screen {
 ...
}
```

All of the rules inside will get the debug markers, but firesass won't be able to see them.
